### PR TITLE
Added a hint for the key import commands

### DIFF
--- a/site/install-rpm.md
+++ b/site/install-rpm.md
@@ -180,6 +180,14 @@ rpm --import https://packagecloud.io/rabbitmq/erlang/gpgkey
 rpm --import https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey
 </pre>
 
+Note that if any of the above import commands finishes with an error due to the SHA1 hash algorithm, you must execute the following first:
+
+<pre class="lang-bash">
+sudo update-crypto-policies --set LEGACY
+</pre>
+
+And then retry the failed import command(s).
+
 ### Add Yum Repositories for RabbitMQ and Modern Erlang
 
 In order to use the Yum repository, a `.repo` file (e.g. `rabbitmq.repo`) has to be


### PR DESCRIPTION
Because of the hash algorithm in use (SHA1) for the Erlang and RabbitMQ server repository, the appropriate rpm import commands will fail. A possible workaround is to switch the crypto policies to legacy.